### PR TITLE
Migrate npm publishing to Trusted Publisher

### DIFF
--- a/.github/workflows/npm_publish.yml
+++ b/.github/workflows/npm_publish.yml
@@ -5,6 +5,9 @@ on:
 jobs:
   npm-publish:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write  # Required for OIDC authentication
+      contents: read   # Required for repository access
     steps:
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -14,9 +17,9 @@ jobs:
           node-version: "20"
           cache: "npm"
           registry-url: "https://registry.npmjs.org"
+      - name: Upgrade npm to latest
+        run: npm install -g npm@latest
       - run: npm ci
       - run: npm run build
       - name: Publish package on NPM 📦
         run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}


### PR DESCRIPTION
## Summary

This PR migrates npm package publishing from token-based authentication to NPM Trusted Publisher with OIDC authentication.

## Changes

- ✅ Added OIDC permissions to GitHub Actions workflow
- ✅ Added npm upgrade step for latest OIDC support  
- ✅ Removed NPM token authentication from workflow
- ✅ Deleted `NPM_PUBLISH_TOKEN` from repository secrets

## Security Improvements

- Enhanced security through OIDC authentication
- Provenance statements for package integrity
- Elimination of long-lived tokens
- Two-factor authentication requirement

## Next Steps

After this PR is merged, you'll need to:

1. **Configure NPM Trusted Publisher**:
   - Visit: https://www.npmjs.com/package/@masatomakino/gulptask-dev-server/access
   - Add GitHub Actions trusted publisher with:
     - GitHub Owner: `MasatoMakino`
     - Repository: `gulptask-dev-server`
     - Workflow filename: `npm_publish.yml`

2. **Update Publishing Access Settings**:
   - Set to "Require two-factor authentication and disallow tokens (recommended)"

## Testing

The migration can be tested by creating a release after completing the NPM configuration steps above.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the package publishing pipeline to enhance security and reliability, adopting modern authentication and permissions.
  * Upgrades npm to the latest version during publishing to ensure compatibility and more consistent installs.
  * Maintains existing release triggers and build steps; no changes to application behavior or user-facing features.
  * Expect smoother, more reliable releases with reduced maintenance overhead and improved compliance with best practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->